### PR TITLE
Visop 3750

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+# Pull Request
+
+**_ IMPORTANT: If you are a candidate, please do not open a PR or push your changes. _**
+
+Please describe the changes this PR makes, giving a concise but thorough summary of what you changed and why.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.0'
+	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 


### PR DESCRIPTION
Update Spring Boot to 3.5.3 to patch the tomcat security vulnerability. [Details](https://spring.io/blog/2025/06/19/spring-boot-3-5-3-available-now).

I'm also updating the PR template as the generic GetYourGuide one does not fit the interview repository.
