### PR TITLE
BOOT-4: [NO_TICKET] Update spring boot to 4.0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.3'
+	id 'org.springframework.boot' version '4.0.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 


### PR DESCRIPTION
## Summary

This PR updates the Spring Boot Gradle plugin from version `4.0.3` to `4.0.5`, a patch-level upgrade with no associated Jira ticket.

## Changes

- **`build.gradle`**: Bumped `org.springframework.boot` plugin version from `4.0.3` → `4.0.5`.

## Notes

- This is a patch upgrade (4.0.3 → 4.0.5), which typically includes bug fixes and minor improvements with no breaking changes.
- Note: there is a minor inconsistency between the branch name (`spring-boot-4.0.4`) and the actual target version (`4.0.5`) applied in the diff.

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->