### PR TITLE
LTECH-405: Run tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: [self-hosted, java-large]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: eu-central-1
+          role-to-assume: arn:aws:iam::130607246975:role/ci-base-access
+          role-session-name: swe-interview-test
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version-file: .sdkmanrc
+
+      - name: Run tests
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        with:
+          gradle-version: wrapper
+          arguments: |
+            --build-cache test
+        env:
+          CODEARTIFACT_AUTH_TOKEN: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
@@ -15,17 +14,10 @@ concurrency:
 jobs:
   test:
     name: Run Tests
-    runs-on: [self-hosted, java-large]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
-        with:
-          aws-region: eu-central-1
-          role-to-assume: arn:aws:iam::130607246975:role/ci-base-access
-          role-session-name: swe-interview-test
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -39,5 +31,3 @@ jobs:
           gradle-version: wrapper
           arguments: |
             --build-cache test
-        env:
-          CODEARTIFACT_AUTH_TOKEN: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Introduces a GitHub Actions CI workflow to automatically run tests for the `spring-boot-starter` branch, as part of the LTECH-405 initiative.

## Changes

- Adds `.github/workflows/test.yml`, a new CI pipeline named **Test** that triggers on every `push` and supports manual dispatch via `workflow_dispatch`.

## Workflow Details

- **Runner:** Self-hosted `java-large` runner.
- **Concurrency:** Configured to cancel in-progress runs on non-default branches, avoiding redundant executions.
- **Steps:**
  1. **Checkout** sources (pinned `actions/checkout@v6.0.2`).
  2. **Configure AWS credentials** via OIDC (`aws-actions/configure-aws-credentials@v5.1.1`) targeting the `ci-base-access` IAM role in `eu-central-1` — likely needed to authenticate with AWS CodeArtifact for dependency resolution.
  3. **Setup Java** using Temurin distribution, with the version sourced from `.sdkmanrc` (`actions/setup-java@v5.2.0`).
  4. **Run tests** via the Gradle build action (`gradle/gradle-build-action@v3.5.0`), using the Gradle wrapper with build cache enabled.

## Notes

- All actions are pinned to specific commit SHAs for supply chain security.
- `CODEARTIFACT_AUTH_TOKEN` is passed as a secret to authenticate private package resolution during the test run.


---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->