### PR TITLE
add `spring-boot-starter-flyway`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-flyway'
 	implementation 'org.flywaydb:flyway-core'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'


### PR DESCRIPTION
## Summary

Adds the `spring-boot-starter-flyway` dependency to `build.gradle` alongside the already-present `flyway-core` dependency. The Spring Boot Flyway starter ensures proper auto-configuration of Flyway within the Spring Boot context, enabling seamless database migration management on application startup.

## Changes

- **`build.gradle`**: Added `org.springframework.boot:spring-boot-starter-flyway` as an `implementation` dependency, complementing the existing `org.flywaydb:flyway-core` entry.

## Notes

- No ticket referenced (`NO-TICKET`); this appears to be a small fix to ensure Flyway is correctly wired into the Spring Boot auto-configuration lifecycle.
- Only 1 line added across 1 file — minimal footprint change.

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->